### PR TITLE
feat: Add go-to-definition for #Include statements and cross-file symbols

### DIFF
--- a/client/src/test/definition.test.ts
+++ b/client/src/test/definition.test.ts
@@ -69,6 +69,29 @@ suite('Should do definition', () => {
 			'Should navigate to the included file'
 		);
 	});
+
+	test('Navigate to #Include file with trailing comment', async () => {
+		// Arrange
+		const expectedTargetUri = getDocUri('included_lib.ahk');
+		// Line 3 has: #Include included_lib.ahk ; with trailing comment
+		const position = new vscode.Position(3, 10);
+
+		// Act
+		await activate(includeTestUri);
+		const actualDefinition = (await vscode.commands.executeCommand(
+			'vscode.executeDefinitionProvider',
+			includeTestUri,
+			position
+		)) as vscode.Location[];
+
+		// Assert
+		assert.strictEqual(actualDefinition.length, 1, 'Should return exactly one definition');
+		assert.strictEqual(
+			actualDefinition[0].uri.fsPath,
+			expectedTargetUri.fsPath,
+			'Should navigate to the included file despite trailing comment'
+		);
+	});
 });
 
 async function testDefinition(

--- a/client/src/test/definition.test.ts
+++ b/client/src/test/definition.test.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { getDocUri, activate } from './helper';
+import { getDocUri, getDocPath, activate } from './helper';
 
 suite('Should do definition', () => {
 	const docUri = getDocUri('completion.ahk');
+	const includeTestUri = getDocUri('include_test.ahk');
 
 	test('Find global symbol', async () => {
 		await testDefinition(docUri, new vscode.Position(32-1, 2), [{
@@ -43,6 +44,30 @@ suite('Should do definition', () => {
 			),
 			uri: docUri
 		}]);
+	});
+
+	test('Navigate to #Include file', async () => {
+		// Arrange
+		const expectedTargetUri = getDocUri('included_lib.ahk');
+		// Line 2 has: #Include included_lib.ahk
+		// Position on the include path (column 10 is within "included_lib.ahk")
+		const position = new vscode.Position(2, 10);
+
+		// Act
+		await activate(includeTestUri);
+		const actualDefinition = (await vscode.commands.executeCommand(
+			'vscode.executeDefinitionProvider',
+			includeTestUri,
+			position
+		)) as vscode.Location[];
+
+		// Assert
+		assert.strictEqual(actualDefinition.length, 1, 'Should return exactly one definition');
+		assert.strictEqual(
+			actualDefinition[0].uri.fsPath,
+			expectedTargetUri.fsPath,
+			'Should navigate to the included file'
+		);
 	});
 });
 

--- a/client/testFixture/include_test.ahk
+++ b/client/testFixture/include_test.ahk
@@ -1,6 +1,7 @@
 ; Test file for #Include go-to-definition
 
 #Include included_lib.ahk
+#Include included_lib.ahk ; with trailing comment
 
 TestFunc() {
 	result := LibraryFunction()

--- a/client/testFixture/include_test.ahk
+++ b/client/testFixture/include_test.ahk
@@ -1,0 +1,8 @@
+; Test file for #Include go-to-definition
+
+#Include included_lib.ahk
+
+TestFunc() {
+	result := LibraryFunction()
+	return result
+}

--- a/client/testFixture/included_lib.ahk
+++ b/client/testFixture/included_lib.ahk
@@ -1,0 +1,5 @@
+; Library file used by include_test.ahk
+
+LibraryFunction() {
+	return "Hello from library"
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,12 +9,22 @@
 			"version": "0.4.0",
 			"license": "LGPLv3.0",
 			"dependencies": {
+				"ignore": "^7.0.5",
 				"vscode-languageserver": "^9.0.1",
 				"vscode-languageserver-textdocument": "^1.0.11",
 				"vscode-uri": "^3.0.7"
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/vscode-jsonrpc": {
@@ -64,6 +74,11 @@
 		}
 	},
 	"dependencies": {
+		"ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
+		},
 		"vscode-jsonrpc": {
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
 		"url": "https://github.com/helsmy/vscode-autohotkey"
 	},
 	"dependencies": {
+		"ignore": "^7.0.5",
 		"vscode-languageserver": "^9.0.1",
 		"vscode-languageserver-textdocument": "^1.0.11",
 		"vscode-uri": "^3.0.7"

--- a/server/src/ahkls.ts
+++ b/server/src/ahkls.ts
@@ -439,7 +439,12 @@ export class AHKLS
         const lineText = docinfo.getLine(position.line);
         const includeMatch = lineText.match(/^\s*#include[,]?\s*/i);
         if (includeMatch) {
-            const rawPath = lineText.slice(includeMatch[0].length).trim();
+            let rawPath = lineText.slice(includeMatch[0].length).trim();
+            // Strip trailing comment (AHK requires space before ;)
+            const commentIndex = rawPath.indexOf(' ;');
+            if (commentIndex !== -1) {
+                rawPath = rawPath.substring(0, commentIndex).trim();
+            }
             const docPath = URI.parse(textDocument.uri).fsPath;
             const docDir = dirname(docPath);
             const resolvedPath = this.documentService.include2Path(rawPath, docDir);

--- a/server/src/ahkls.ts
+++ b/server/src/ahkls.ts
@@ -113,16 +113,9 @@ export class AHKLS
 
     private logger: ILoggerBase;
 
-    private _documentService: DocumentService;
+    public readonly documentService: DocumentService;
     // text document manager
     private documents: TextDocuments<TextDocument>;
-
-    /**
-     * Get the document service for external access (e.g., file watching)
-     */
-    public get documentService(): DocumentService {
-        return this._documentService;
-    }
 
     private ioService: IoService;
 
@@ -145,7 +138,7 @@ export class AHKLS
         this.finder = new ScriptASTFinder();
         this.logger = logger;
         this.documents = new TextDocuments(TextDocument);
-        this._documentService = new DocumentService(conn, this.documents, logger, this.v2CompatibleMode);
+        this.documentService = new DocumentService(conn, this.documents, logger, this.v2CompatibleMode);
         this.ioService = new IoService();
         this.configurationService = config;
 

--- a/server/src/parser/newtry/analyzer/models/symbolInformationProvider.ts
+++ b/server/src/parser/newtry/analyzer/models/symbolInformationProvider.ts
@@ -52,6 +52,22 @@ export function symbolInformations(symbols: Map<string, AHKSymbol>, uri: string)
 	return info;
 }
 
+export function getSymbolKind(sym: ISymbol): SymbolKind {
+	if (sym instanceof VariableSymbol) {
+		return sym.tag === VarKind.variable ? SymbolKind.Variable : SymbolKind.Property;
+	}
+	else if (sym instanceof AHKMethodSymbol) {
+		return SymbolKind.Method;
+	}
+	else if (sym instanceof AHKObjectSymbol) {
+		return SymbolKind.Class;
+	}
+	else if (sym instanceof HotkeySymbol || sym instanceof HotStringSymbol) {
+		return SymbolKind.Event;
+	}
+	return SymbolKind.Variable;
+}
+
 export function symbolInfomationName(sym: ISymbol): string {
 	if (sym.name !== '') return sym.name;
 	if (sym instanceof VariableSymbol) {

--- a/server/src/services/documentService.ts
+++ b/server/src/services/documentService.ts
@@ -418,7 +418,7 @@ export class DocumentService {
         });
     }
 
-    private include2Path(rawPath: string, scriptPath: string): Maybe<string> {
+    public include2Path(rawPath: string, scriptPath: string): Maybe<string> {
         const scriptDir = scriptPath;
         const normalized = normalize(rawPath);
         switch (extname(normalized)) {

--- a/server/src/services/documentService.ts
+++ b/server/src/services/documentService.ts
@@ -1,5 +1,6 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { IoService } from './ioService';
+import { WorkspaceIndex } from './workspaceIndex';
 import { mockLogger } from '../utilities/logger';
 import { DocumentSyntaxInfo } from './types';
 import { Connection, Diagnostic, Position, Range, TextDocuments } from 'vscode-languageserver/node';
@@ -99,6 +100,16 @@ export class DocumentService {
 
     private _configurationDone = new Notifier();
 
+    /**
+     * Workspace root directory
+     */
+    private workspaceRoot: string | undefined;
+
+    /**
+     * Workspace-wide symbol index
+     */
+    public readonly workspaceIndex: WorkspaceIndex = new WorkspaceIndex();
+
     constructor(
         private conn: Connection, 
         documents: TextDocuments<TextDocument>,
@@ -123,6 +134,20 @@ export class DocumentService {
         const doc = this.serverDocs.get(uri);
         if (!info || !doc) return undefined;
         return new DocumentInfomation(doc, info);
+    }
+
+    /**
+     * Get all open document information for workspace symbol search
+     */
+    public getAllDocumentInfo(): Map<string, DocumentInfomation> {
+        const result = new Map<string, DocumentInfomation>();
+        for (const [uri, info] of this.docsAST) {
+            const doc = this.serverDocs.get(uri);
+            if (doc) {
+                result.set(uri, new DocumentInfomation(doc, info));
+            }
+        }
+        return result;
     }
 
     public onConfigChange(config: ConfigurationService) {
@@ -170,6 +195,10 @@ export class DocumentService {
         const processer = new Processer(ast.script, this.v2CompatibleMode, processResult.table);
         const sencondResult = processer.process();
         const docTable = sencondResult.table;
+
+        // Connect workspace index to enable cross-file symbol resolution
+        docTable.setWorkspaceSymbolProvider(this.workspaceIndex);
+
         const end = Date.now();
         this.logger.log(`Analzay finished[${end - start} ms]`);
 
@@ -446,6 +475,109 @@ export class DocumentService {
             default:
                 return undefined;
         }
+    }
+
+    // ==================== Workspace Indexing ====================
+
+    /**
+     * Set the workspace root and prepare for scanning
+     * @param root Workspace root directory path
+     */
+    public setWorkspaceRoot(root: string): void {
+        this.workspaceRoot = root;
+        this.workspaceIndex.clear();
+    }
+
+    /**
+     * Scan all .ahk files in the workspace and index their symbols
+     * @param progressCallback Optional callback for progress updates
+     */
+    public async scanWorkspace(progressCallback?: (processed: number, total: number) => void): Promise<void> {
+        if (!this.workspaceRoot) {
+            this.logger.warn('No workspace root set, cannot scan');
+            return;
+        }
+
+        this.workspaceIndex.isIndexing = true;
+
+        try {
+            const files = this.ioService.findFilesRecursive(this.workspaceRoot, '.ahk');
+            const totalFiles = files.length;
+            let processed = 0;
+
+            // Process files in batches to avoid blocking
+            const BATCH_SIZE = 10;
+            for (let i = 0; i < files.length; i += BATCH_SIZE) {
+                const batch = files.slice(i, i + BATCH_SIZE);
+
+                for (const filePath of batch) {
+                    await this.indexFile(filePath);
+                    processed++;
+                    if (progressCallback) {
+                        progressCallback(processed, totalFiles);
+                    }
+                }
+
+                // Yield to event loop between batches
+                if (i + BATCH_SIZE < files.length) {
+                    await new Promise(resolve => setImmediate(resolve));
+                }
+            }
+
+            this.logger.info(`Indexed ${processed} files in workspace`);
+        } finally {
+            this.workspaceIndex.isIndexing = false;
+        }
+    }
+
+    /**
+     * Index a single file into the workspace index
+     * @param filePath Absolute path to the file
+     */
+    public async indexFile(filePath: string): Promise<void> {
+        const uri = URI.file(filePath).toString();
+
+        // Skip if already open in editor (handled by docsAST)
+        if (this.docsAST.has(uri)) return;
+
+        try {
+            const content = await this.ioService.load(filePath);
+            const parser = new AHKParser(content, uri, this.v2CompatibleMode, this.logger);
+            const ast = parser.parse();
+            const preprocesser = new PreProcesser(
+                ast.script,
+                this.v2CompatibleMode ? this.builtinScope.v2 : this.builtinScope.v1
+            );
+            const processResult = preprocesser.process();
+
+            // Extract top-level symbols for the index
+            const symbols = processResult.table.allSymbols() as AHKSymbol[];
+            this.workspaceIndex.addFile(uri, symbols);
+        } catch (err) {
+            this.logger.error(`Failed to index ${filePath}: ${err}`);
+        }
+    }
+
+    /**
+     * Re-index a file (remove old entry and index again)
+     * @param filePath Absolute path to the file
+     */
+    public async reindexFile(filePath: string): Promise<void> {
+        const uri = URI.file(filePath).toString();
+
+        // Skip if open in editor
+        if (this.docsAST.has(uri)) return;
+
+        this.workspaceIndex.removeFile(uri);
+        await this.indexFile(filePath);
+    }
+
+    /**
+     * Remove a file from the workspace index
+     * @param uri File URI to remove
+     */
+    public removeFileFromIndex(uri: string): void {
+        this.workspaceIndex.removeFile(uri);
     }
 }
 

--- a/server/src/services/workspaceIndex.ts
+++ b/server/src/services/workspaceIndex.ts
@@ -1,0 +1,104 @@
+import { AHKMethodSymbol, AHKObjectSymbol, AHKSymbol, VariableSymbol } from '../parser/newtry/analyzer/models/symbol';
+
+export interface WorkspaceSymbolEntry {
+    uri: string;
+    symbol: AHKSymbol;
+}
+
+/**
+ * Stores and queries workspace-wide symbols for cross-file go-to-definition
+ */
+export class WorkspaceIndex {
+    private fileSymbols: Map<string, AHKSymbol[]> = new Map();
+    private symbolLookup: Map<string, WorkspaceSymbolEntry[]> = new Map();
+    public isIndexing: boolean = false;
+
+    /**
+     * Add symbols from a file to the index
+     */
+    public addFile(uri: string, symbols: AHKSymbol[]): void {
+        // Remove old symbols if file was previously indexed
+        this.removeFile(uri);
+
+        // Store file's symbols
+        this.fileSymbols.set(uri, symbols);
+
+        // Add to lookup by name
+        for (const symbol of symbols) {
+            const name = symbol.name.toLowerCase();
+            const entries = this.symbolLookup.get(name) || [];
+            entries.push({ uri, symbol });
+            this.symbolLookup.set(name, entries);
+        }
+    }
+
+    /**
+     * Remove a file's symbols from the index
+     */
+    public removeFile(uri: string): void {
+        const symbols = this.fileSymbols.get(uri);
+        if (!symbols) return;
+
+        // Remove from lookup
+        for (const symbol of symbols) {
+            const name = symbol.name.toLowerCase();
+            const entries = this.symbolLookup.get(name);
+            if (entries) {
+                const filtered = entries.filter(e => e.uri !== uri);
+                if (filtered.length === 0) {
+                    this.symbolLookup.delete(name);
+                } else {
+                    this.symbolLookup.set(name, filtered);
+                }
+            }
+        }
+
+        this.fileSymbols.delete(uri);
+    }
+
+    /**
+     * Find symbols by name (case-insensitive)
+     */
+    public findByName(name: string): WorkspaceSymbolEntry[] {
+        return this.symbolLookup.get(name.toLowerCase()) || [];
+    }
+
+    /**
+     * Get all symbols, optionally filtered by query
+     */
+    public getAllSymbols(query?: string): WorkspaceSymbolEntry[] {
+        const results: WorkspaceSymbolEntry[] = [];
+        const lowerQuery = query?.toLowerCase();
+
+        // Use forEach for better compatibility with bundlers
+        this.symbolLookup.forEach((entries, name) => {
+            if (!lowerQuery || name.includes(lowerQuery)) {
+                results.push(...entries);
+            }
+        });
+
+        return results;
+    }
+
+    /**
+     * Clear all indexed symbols
+     */
+    public clear(): void {
+        this.fileSymbols.clear();
+        this.symbolLookup.clear();
+    }
+
+    /**
+     * Check if a file is indexed
+     */
+    public hasFile(uri: string): boolean {
+        return this.fileSymbols.has(uri);
+    }
+
+    /**
+     * Get count of indexed files
+     */
+    public get indexedFileCount(): number {
+        return this.fileSymbols.size;
+    }
+}

--- a/server/src/test/ioService.test.ts
+++ b/server/src/test/ioService.test.ts
@@ -1,0 +1,119 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { IoService } from '../services/ioService';
+
+suite('IoService Test', () => {
+    let tempDir: string;
+    let ioService: IoService;
+
+    setup(() => {
+        // Arrange
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ioservice-test-'));
+        ioService = new IoService();
+    });
+
+    teardown(() => {
+        // Cleanup - using rmdirSync for compatibility with older Node.js
+        const deleteRecursive = (dir: string) => {
+            if (fs.existsSync(dir)) {
+                fs.readdirSync(dir).forEach((file) => {
+                    const fullPath = path.join(dir, file);
+                    if (fs.lstatSync(fullPath).isDirectory()) {
+                        deleteRecursive(fullPath);
+                    } else {
+                        fs.unlinkSync(fullPath);
+                    }
+                });
+                fs.rmdirSync(dir);
+            }
+        };
+        deleteRecursive(tempDir);
+    });
+
+    test('should find .ahk files recursively', () => {
+        // Arrange
+        fs.writeFileSync(path.join(tempDir, 'test1.ahk'), '');
+        fs.mkdirSync(path.join(tempDir, 'subdir'));
+        fs.writeFileSync(path.join(tempDir, 'subdir', 'test2.ahk'), '');
+
+        // Act
+        const results = ioService.findFilesRecursive(tempDir, '.ahk');
+
+        // Assert
+        assert.strictEqual(results.length, 2);
+    });
+
+    test('should ignore .git directory', () => {
+        // Arrange
+        fs.writeFileSync(path.join(tempDir, 'test.ahk'), '');
+        fs.mkdirSync(path.join(tempDir, '.git'));
+        fs.writeFileSync(path.join(tempDir, '.git', 'hidden.ahk'), '');
+
+        // Act
+        const results = ioService.findFilesRecursive(tempDir, '.ahk');
+
+        // Assert
+        assert.strictEqual(results.length, 1);
+        assert.ok(results[0].endsWith('test.ahk'));
+    });
+
+    test('should respect .gitignore patterns', () => {
+        // Arrange
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), 'ignored/\n*.tmp.ahk');
+        fs.writeFileSync(path.join(tempDir, 'keep.ahk'), '');
+        fs.writeFileSync(path.join(tempDir, 'temp.tmp.ahk'), '');
+        fs.mkdirSync(path.join(tempDir, 'ignored'));
+        fs.writeFileSync(path.join(tempDir, 'ignored', 'skip.ahk'), '');
+
+        // Act
+        const results = ioService.findFilesRecursive(tempDir, '.ahk');
+
+        // Assert
+        assert.strictEqual(results.length, 1);
+        assert.ok(results[0].endsWith('keep.ahk'));
+    });
+
+    test('should ignore node_modules when in .gitignore', () => {
+        // Arrange
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), 'node_modules');
+        fs.writeFileSync(path.join(tempDir, 'main.ahk'), '');
+        fs.mkdirSync(path.join(tempDir, 'node_modules'));
+        fs.writeFileSync(path.join(tempDir, 'node_modules', 'dep.ahk'), '');
+
+        // Act
+        const results = ioService.findFilesRecursive(tempDir, '.ahk');
+
+        // Assert
+        assert.strictEqual(results.length, 1);
+        assert.ok(results[0].endsWith('main.ahk'));
+    });
+
+    test('should work without .gitignore file', () => {
+        // Arrange
+        fs.writeFileSync(path.join(tempDir, 'test.ahk'), '');
+        fs.mkdirSync(path.join(tempDir, 'subdir'));
+        fs.writeFileSync(path.join(tempDir, 'subdir', 'nested.ahk'), '');
+
+        // Act
+        const results = ioService.findFilesRecursive(tempDir, '.ahk');
+
+        // Assert
+        assert.strictEqual(results.length, 2);
+    });
+
+    test('should handle negation patterns in .gitignore', () => {
+        // Arrange
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), '*.ahk\n!important.ahk');
+        fs.writeFileSync(path.join(tempDir, 'normal.ahk'), '');
+        fs.writeFileSync(path.join(tempDir, 'important.ahk'), '');
+
+        // Act
+        const results = ioService.findFilesRecursive(tempDir, '.ahk');
+
+        // Assert
+        assert.strictEqual(results.length, 1);
+        assert.ok(results[0].endsWith('important.ahk'));
+    });
+});

--- a/server/src/test/workspaceIndex.test.ts
+++ b/server/src/test/workspaceIndex.test.ts
@@ -1,0 +1,195 @@
+import * as assert from 'assert';
+import { Range } from 'vscode-languageserver-types';
+import { WorkspaceIndex } from '../services/workspaceIndex';
+import { AHKMethodSymbol, AHKObjectSymbol, VariableSymbol } from '../parser/newtry/analyzer/models/symbol';
+
+// VarKind is a const enum, so we use the numeric value directly
+// VarKind.variable = 0, VarKind.parameter = 1, VarKind.property = 2
+const VAR_KIND_VARIABLE = 0;
+
+function createTestSymbol(name: string, uri: string): VariableSymbol {
+    return new VariableSymbol(
+        uri,
+        name,
+        Range.create(0, 0, 0, name.length),
+        VAR_KIND_VARIABLE
+    );
+}
+
+function createTestClass(name: string, uri: string): AHKObjectSymbol {
+    return new AHKObjectSymbol(
+        uri,
+        name,
+        Range.create(0, 0, 10, 0),
+        undefined,
+        undefined
+    );
+}
+
+function createTestMethod(name: string, uri: string): AHKMethodSymbol {
+    return new AHKMethodSymbol(
+        uri,
+        name,
+        Range.create(0, 0, 5, 0),
+        [],
+        [],
+        undefined
+    );
+}
+
+suite('WorkspaceIndex Test', () => {
+    test('should add and find symbols by name', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        const symbol = createTestSymbol('myVar', 'file:///test.ahk');
+
+        // Act
+        index.addFile('file:///test.ahk', [symbol]);
+        const results = index.findByName('myVar');
+
+        // Assert
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].symbol.name, 'myVar');
+        assert.strictEqual(results[0].uri, 'file:///test.ahk');
+    });
+
+    test('should find symbols case-insensitively', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        const symbol = createTestSymbol('MyClass', 'file:///test.ahk');
+
+        // Act
+        index.addFile('file:///test.ahk', [symbol]);
+
+        // Assert
+        assert.strictEqual(index.findByName('myclass').length, 1);
+        assert.strictEqual(index.findByName('MYCLASS').length, 1);
+        assert.strictEqual(index.findByName('MyClass').length, 1);
+    });
+
+    test('should remove file from index', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        const symbol = createTestSymbol('myVar', 'file:///test.ahk');
+        index.addFile('file:///test.ahk', [symbol]);
+
+        // Act
+        index.removeFile('file:///test.ahk');
+
+        // Assert
+        assert.strictEqual(index.findByName('myVar').length, 0);
+        assert.strictEqual(index.indexedFileCount, 0);
+    });
+
+    test('should track indexed file count', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+
+        // Act
+        index.addFile('file:///test1.ahk', [createTestSymbol('var1', 'file:///test1.ahk')]);
+        index.addFile('file:///test2.ahk', [createTestSymbol('var2', 'file:///test2.ahk')]);
+
+        // Assert
+        assert.strictEqual(index.indexedFileCount, 2);
+    });
+
+    test('should handle multiple symbols with same name from different files', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        const symbol1 = createTestSymbol('Config', 'file:///file1.ahk');
+        const symbol2 = createTestSymbol('Config', 'file:///file2.ahk');
+
+        // Act
+        index.addFile('file:///file1.ahk', [symbol1]);
+        index.addFile('file:///file2.ahk', [symbol2]);
+        const results = index.findByName('Config');
+
+        // Assert
+        assert.strictEqual(results.length, 2);
+    });
+
+    test('should re-index file when adding same URI', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        const symbol1 = createTestSymbol('oldVar', 'file:///test.ahk');
+        const symbol2 = createTestSymbol('newVar', 'file:///test.ahk');
+
+        // Act
+        index.addFile('file:///test.ahk', [symbol1]);
+        index.addFile('file:///test.ahk', [symbol2]);
+
+        // Assert
+        assert.strictEqual(index.findByName('oldVar').length, 0);
+        assert.strictEqual(index.findByName('newVar').length, 1);
+        assert.strictEqual(index.indexedFileCount, 1);
+    });
+
+    test('should clear all symbols', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        index.addFile('file:///test1.ahk', [createTestSymbol('var1', 'file:///test1.ahk')]);
+        index.addFile('file:///test2.ahk', [createTestSymbol('var2', 'file:///test2.ahk')]);
+
+        // Act
+        index.clear();
+
+        // Assert
+        assert.strictEqual(index.indexedFileCount, 0);
+        assert.strictEqual(index.findByName('var1').length, 0);
+        assert.strictEqual(index.findByName('var2').length, 0);
+    });
+
+    test('should check if file is indexed', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        index.addFile('file:///test.ahk', [createTestSymbol('var1', 'file:///test.ahk')]);
+
+        // Act & Assert
+        assert.strictEqual(index.hasFile('file:///test.ahk'), true);
+        assert.strictEqual(index.hasFile('file:///other.ahk'), false);
+    });
+
+    test('should index multiple symbols from same file', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        index.addFile('file:///test.ahk', [
+            createTestSymbol('MyClass', 'file:///test.ahk'),
+            createTestSymbol('MyFunction', 'file:///test.ahk'),
+            createTestSymbol('OtherThing', 'file:///test.ahk')
+        ]);
+
+        // Act & Assert - verify all symbols are indexed and findable
+        assert.strictEqual(index.findByName('MyClass').length, 1);
+        assert.strictEqual(index.findByName('MyFunction').length, 1);
+        assert.strictEqual(index.findByName('OtherThing').length, 1);
+        assert.strictEqual(index.indexedFileCount, 1);
+    });
+
+    test('should index class symbols', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        const classSymbol = createTestClass('MyClass', 'file:///test.ahk');
+
+        // Act
+        index.addFile('file:///test.ahk', [classSymbol]);
+        const results = index.findByName('MyClass');
+
+        // Assert
+        assert.strictEqual(results.length, 1);
+        assert.ok(results[0].symbol instanceof AHKObjectSymbol);
+    });
+
+    test('should index method symbols', () => {
+        // Arrange
+        const index = new WorkspaceIndex();
+        const methodSymbol = createTestMethod('DoSomething', 'file:///test.ahk');
+
+        // Act
+        index.addFile('file:///test.ahk', [methodSymbol]);
+        const results = index.findByName('DoSomething');
+
+        // Assert
+        assert.strictEqual(results.length, 1);
+        assert.ok(results[0].symbol instanceof AHKMethodSymbol);
+    });
+});


### PR DESCRIPTION
## Summary
- Go-to-definition support for `#Include` statements (navigates to the included file)
- Workspace-wide symbol indexing for cross-file go-to-definition
- Handles trailing comments after `#Include` paths

## Changes
- Added `workspaceIndex.ts` service for indexing symbols across workspace files
- Extended definition provider in `ahkls.ts` to resolve #Include paths and cross-file symbols
- Added `ignore` package dependency for respecting .gitignore patterns during indexing
- Updated `documentService.ts` with workspace root configuration and include path resolution

## Test plan
- [x] Added tests for #Include go-to-definition with and without trailing comments
- [x] Added tests for workspace symbol indexing
- [x] Added test fixtures (`include_test.ahk`, `included_lib.ahk`)